### PR TITLE
Update GeneralRequestInterface.php

### DIFF
--- a/Pagador/Transaction/Api/AntiFraud/MDD/GeneralRequestInterface.php
+++ b/Pagador/Transaction/Api/AntiFraud/MDD/GeneralRequestInterface.php
@@ -13,7 +13,7 @@ interface GeneralRequestInterface
     const MDD_KEY_PRODUCT_CATEGORY = 5;
     const MDD_KEY_SHIPPING_METHOD = 7;
     const MDD_KEY_CUSTOMER_FETCH_SELF = 9;
-    const MDD_KEY_STORE_CODE = 10;
+    const MDD_KEY_STORE_CODE = 22;
     const MDD_KEY_COUPON_CODE = 12;
     const MDD_KEY_HAS_GIFT_CARD = 13;
     const MDD_KEY_SECOND_PAYMENT_METHOD = 14;
@@ -24,7 +24,7 @@ interface GeneralRequestInterface
     const MDD_KEY_QTY_INSTALLMENTS_ORDER = 19;
     const MDD_KEY_CARD_IS_PRIVATE_LABEL = 20;
     const MDD_KEY_CUSTOMER_IDENTITY = 21;
-    const MDD_KEY_CUSTOMER_TELEPHONE = 22;
+    const MDD_KEY_CUSTOMER_TELEPHONE = 38;
     const MDD_KEY_STORE_IDENTITY = 23;
     const MDD_KEY_PROVIDER = 24;
     const MDD_KEY_CUSTOMER_IS_RISK = 25;


### PR DESCRIPTION
Esse ajuste visa corrigir falha de implementação das MDDs de acordo com a documentação oficial da braspag abaixo:
https://braspag.github.io//manual/braspag-pagador#tabela-de-mdds

No meu cenário onde o projeto é multistore e usa o MSI (Multisource stock inventory) tentei fazer plugin ou preference para reescrever essa classe e redefinir esses valores que são usados na private function getMDDs(GeneralRequestInterface $data) e não consegui.

Fiz um plugin nos métodos public function afterGetStoreCode e public function afterGetCustomerFetchSelf da classe Webjump\BraspagPagador\Gateway\Transaction\AntiFraud\Resource\MDD\GeneralRequest para poder corrigir isso, mas como o ID do que deveria ser o MDD22 está vindo como 10 que é o valor definido na linha 22 da Interface GeneralRequestInterface na constante MDD_KEY_STORE_CODE, o time da braspag sugeriu que fosse feita essa alteração.

Com isso conseguirei que o ID atribuido a constante MDD_KEY_STORE_CODE fique 22 que é o correto de acordo com a tabela oficial da braspag, e seu valor fique dinâmico no meu plugin no meu projeto, que no caso é o source_code da MSI.